### PR TITLE
Do NOT use version from maven project.

### DIFF
--- a/apikana-maven-plugin/src/main/java/org/swisspush/apikana/AbstractApikanaMojo.java
+++ b/apikana-maven-plugin/src/main/java/org/swisspush/apikana/AbstractApikanaMojo.java
@@ -158,7 +158,6 @@ public abstract class AbstractApikanaMojo extends AbstractMojo {
     protected void generatePackageJson(String version) throws IOException {
         updateJson(working("package.json"), pack -> {
             pack.put("name", mavenProject.getArtifactId());
-            pack.put("version", mavenProject.getVersion());
             final Map<String, String> scripts = (Map) pack.merge("scripts", new HashMap<>(), (oldVal, newVal) -> oldVal);
             scripts.put("apikana", "apikana");
             final Map<String, String> devDependencies = (Map) pack.merge("devDependencies", new HashMap<>(), (oldVal, newVal) -> oldVal);


### PR DESCRIPTION
Because that version we'll find there may isn't a valid semver version.
But npm requires versions to be valid semver version as mentioned in its
documentation [1].

Seems enough to simply not provide the version property in the generated
package.json file.

[1] npm version: "https://docs.npmjs.com/files/package.json#version"

@nidi3 or @lbovet or someone else: Please review (& merge).